### PR TITLE
Add more linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:
+      - id: check-toml
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-merge-conflict
@@ -28,3 +29,9 @@ repos:
         entry: pixi run -e lint cargo clippy
         types: [rust]
         pass_filenames: false
+      - id: actionling
+        name: Lint GitHub Actions workflow files
+        language: system
+        entry: pixi run -e lint actionlint
+        types: [yaml]
+        files: ^\.github/workflows/

--- a/pixi.lock
+++ b/pixi.lock
@@ -28,29 +28,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-wasm32-unknown-unknown-1.79.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.79.0-h2c6d0dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-he073ed8_2.conda
-      linux-aarch64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-aarch64_curr_repodata_hack-4-h57d6b7b_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.40-hf1166c9_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.40-hf54a868_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.40-h1f91aba_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.7.0-h31becfc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-12.3.0-hdb0cc85_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-12.3.0-h3d98823_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-12.3.0-ha52a6ea_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h5b4a56d_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.40-h9fc2d93_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-12.3.0-h6144e03_113.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.1.0-he277a41_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.1.0-he277a41_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-12.3.0-h57e2e72_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.1.0-h3f4de04_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h68df207_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rust-1.79.0-h3393a65_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-src-1.79.0-unix_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-unknown-linux-gnu-1.79.0-hbe8e118_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-wasm32-unknown-unknown-1.79.0-unix_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_14.conda
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.7.0-h282daa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.6.2-h8857fd0_0.conda
@@ -183,61 +160,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
-      linux-aarch64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-aarch64_curr_repodata_hack-4-h57d6b7b_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.40-hf1166c9_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.40-hf54a868_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.40-h1f91aba_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h31becfc_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.7.0-h31becfc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.6.2-hcefe29a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-1.16.0-py312hf3c74c0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-12.3.0-hdb0cc85_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-12.3.0-h3d98823_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-12.3.0-ha52a6ea_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.36-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h5b4a56d_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.40-h9fc2d93_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.2-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-12.3.0-h6144e03_113.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.1.0-he277a41_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.1.0-he277a41_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-12.3.0-h57e2e72_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.46.0-hf51ef55_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.1.0-h3f4de04_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h68df207_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-h0425590_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.1-h68df207_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.1.1-pyha770c72_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.4-h829453d_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.12-4_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.1-py312hdd3e373_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8fc344f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rust-1.79.0-h3393a65_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-src-1.79.0-unix_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-unknown-linux-gnu-1.79.0-hbe8e118_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-wasm32-unknown-unknown-1.79.0-unix_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/typst-0.11.1-h00d8b65_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/typst-test-0.0.0.post104.7babfc0-h09b8157_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ukkonen-1.0.1-py312h8f0b210_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-hf897c2e_2.tar.bz2
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.7.0-h282daa2_1.conda
@@ -406,13 +328,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.1.0-h77fa898_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4ab18f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/typst-0.11.1-h3c1dd8f_0.conda
-      linux-aarch64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.6.2-hcefe29a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.1.0-he277a41_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.1.0-he277a41_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.1-h68df207_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/typst-0.11.1-h00d8b65_0.conda
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/typst-0.11.1-hdd0fa2f_0.conda
       osx-arm64:
@@ -430,6 +345,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-64_curr_repodata_hack-3-h69a702a_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.1-h4bc722e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.40-h4852527_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-ha1999f0_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hb3c18ed_9.conda
@@ -451,31 +367,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.79.0-h2c6d0dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-he073ed8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/typos-1.22.7-he9194b0_0.conda
-      linux-aarch64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-aarch64_curr_repodata_hack-4-h57d6b7b_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.40-hf1166c9_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.40-hf54a868_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.40-h1f91aba_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.7.0-h31becfc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-12.3.0-hdb0cc85_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-12.3.0-h3d98823_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-12.3.0-ha52a6ea_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h5b4a56d_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.40-h9fc2d93_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-12.3.0-h6144e03_113.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.1.0-he277a41_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.1.0-he277a41_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-12.3.0-h57e2e72_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.1.0-h3f4de04_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h68df207_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rust-1.79.0-h3393a65_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-src-1.79.0-unix_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-unknown-linux-gnu-1.79.0-hbe8e118_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-wasm32-unknown-unknown-1.79.0-unix_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/typos-1.22.7-h09b8157_0.conda
       osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.1-h68b2b72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.7.0-h282daa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.6.2-h8857fd0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools-986-h40f6528_0.conda
@@ -509,6 +402,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
       osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.1-h99b78c6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.7.0-h6aa9301_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.6.2-hf0a4a13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-986-h4faf515_0.conda
@@ -542,6 +436,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
       win-64:
+      - conda: https://conda.anaconda.org/conda-forge/win-64/actionlint-1.7.1-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/c-compiler-1.7.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
@@ -576,14 +471,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4ab18f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/typst-0.11.1-h3c1dd8f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/typst-test-0.0.0.post104.7babfc0-he9194b0_0.conda
-      linux-aarch64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.6.2-hcefe29a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.1.0-he277a41_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.1.0-he277a41_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.1-h68df207_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/typst-0.11.1-h00d8b65_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/typst-test-0.0.0.post104.7babfc0-h09b8157_0.conda
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/typst-0.11.1-hdd0fa2f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/typst-test-0.0.0.post104.7babfc0-h686f776_0.conda
@@ -627,23 +514,6 @@ packages:
   size: 23621
   timestamp: 1650670423406
 - kind: conda
-  name: _openmp_mutex
-  version: '4.5'
-  build: 2_gnu
-  build_number: 16
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
-  sha256: 3702bef2f0a4d38bd8288bbe54aace623602a1343c2cfbefd3fa188e015bebf0
-  md5: 6168d71addc746e8f2b8d57dfd2edcea
-  depends:
-  - libgomp >=7.5.0
-  constrains:
-  - openmp_impl 9999
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 23712
-  timestamp: 1650670790230
-- kind: conda
   name: _sysroot_linux-64_curr_repodata_hack
   version: '3'
   build: h69a702a_14
@@ -658,19 +528,67 @@ packages:
   size: 21169
   timestamp: 1708000801681
 - kind: conda
-  name: _sysroot_linux-aarch64_curr_repodata_hack
-  version: '4'
-  build: h57d6b7b_14
-  build_number: 14
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-aarch64_curr_repodata_hack-4-h57d6b7b_14.conda
-  sha256: edac93a8e3beb9383abf508f66085505950bc89962116ef149558350a6213749
-  md5: 18f0bdf689b6f345fecddbebaed945d6
-  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
-  license_family: GPL
-  size: 21238
-  timestamp: 1708000885951
+  name: actionlint
+  version: 1.7.1
+  build: h2466b09_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/actionlint-1.7.1-h2466b09_0.conda
+  sha256: 3200bf444a58e72c0d75a4cc194279c40b4ef446acb67eafff659a93fac0f3a4
+  md5: 64c626f2aa8e1158e330db864d9b453c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1746329
+  timestamp: 1718264646472
+- kind: conda
+  name: actionlint
+  version: 1.7.1
+  build: h4bc722e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.1-h4bc722e_0.conda
+  sha256: 343b2bf907d164de74b89722112bc68fdd0ec161db18c83078b2a485466cbb29
+  md5: b2ceeddbf4c04bb9fd12f392ad1f3d14
+  depends:
+  - __glibc >=2.17
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 1716951
+  timestamp: 1718263943052
+- kind: conda
+  name: actionlint
+  version: 1.7.1
+  build: h68b2b72_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.1-h68b2b72_0.conda
+  sha256: 055e5a039c4ab0a8a3b0f75523c946a6bb08ff5f20b4646b0f9735c84670e975
+  md5: 3e0501f5e9945d072478266833db0d50
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx>=10.12
+  license: MIT
+  license_family: MIT
+  size: 1649588
+  timestamp: 1718264033097
+- kind: conda
+  name: actionlint
+  version: 1.7.1
+  build: h99b78c6_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.1-h99b78c6_0.conda
+  sha256: 41dcfe9ca87df4d165aed3d81359818412d1bcebdb0fca46b03684278f4972ff
+  md5: 05a5b1906274bc0a90016723ec19b810
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 1509684
+  timestamp: 1718283229163
 - kind: conda
   name: binutils
   version: '2.40'
@@ -686,21 +604,6 @@ packages:
   license_family: GPL
   size: 31696
   timestamp: 1718625692046
-- kind: conda
-  name: binutils
-  version: '2.40'
-  build: hf1166c9_7
-  build_number: 7
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.40-hf1166c9_7.conda
-  sha256: d9b3be000579bb8c4348667173d353ff222e65dba30b57ddcb60bce9b0680f77
-  md5: b14fec1a6f72700f1f5ec7642ad21bbf
-  depends:
-  - binutils_impl_linux-aarch64 >=2.40,<2.41.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 31854
-  timestamp: 1718625700646
 - kind: conda
   name: binutils_impl_linux-64
   version: '2.40'
@@ -718,22 +621,6 @@ packages:
   size: 6250821
   timestamp: 1718625666382
 - kind: conda
-  name: binutils_impl_linux-aarch64
-  version: '2.40'
-  build: hf54a868_7
-  build_number: 7
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.40-hf54a868_7.conda
-  sha256: 71d3bae11ebe72005216aa359325a6451b9c040c1a2c6411409d093d11f90114
-  md5: 1c626cff2060938c4d7ec45068b50dc3
-  depends:
-  - ld_impl_linux-aarch64 2.40 h9fc2d93_7
-  - sysroot_linux-aarch64
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 6095853
-  timestamp: 1718625674423
-- kind: conda
   name: binutils_linux-64
   version: '2.40'
   build: hb3c18ed_9
@@ -750,22 +637,6 @@ packages:
   size: 29318
   timestamp: 1719005261111
 - kind: conda
-  name: binutils_linux-aarch64
-  version: '2.40'
-  build: h1f91aba_9
-  build_number: 9
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.40-h1f91aba_9.conda
-  sha256: 2890361656496ec4159feaff58b27cf3c75d353ff5059c46d5a5ee9097a04cb9
-  md5: d25d3611be5a27ddb3d9fe47d0ce0f9c
-  depends:
-  - binutils_impl_linux-aarch64 2.40.*
-  - sysroot_linux-aarch64
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 29401
-  timestamp: 1719005234872
-- kind: conda
   name: bzip2
   version: 1.0.8
   build: h10d778d_5
@@ -778,21 +649,6 @@ packages:
   license_family: BSD
   size: 127885
   timestamp: 1699280178474
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h31becfc_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h31becfc_5.conda
-  sha256: b9f170990625cb1eeefaca02e091dc009a64264b077166d8ed7aeb7a09e923b0
-  md5: a64e35f01e0b7a2a152eca87d33b9c87
-  depends:
-  - libgcc-ng >=12
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 189668
-  timestamp: 1699280060686
 - kind: conda
   name: bzip2
   version: 1.0.8
@@ -856,23 +712,6 @@ packages:
   license_family: BSD
   size: 6396
   timestamp: 1714575615177
-- kind: conda
-  name: c-compiler
-  version: 1.7.0
-  build: h31becfc_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.7.0-h31becfc_1.conda
-  sha256: 394249a91908851b44fb93477bb88f42ff94ee225df54b1fec97710661d5a9a9
-  md5: d6ee3d20f681cdb37e631f67bfc76225
-  depends:
-  - binutils
-  - gcc
-  - gcc_linux-aarch64 12.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6329
-  timestamp: 1714575480249
 - kind: conda
   name: c-compiler
   version: 1.7.0
@@ -956,17 +795,6 @@ packages:
   license: ISC
   size: 156035
   timestamp: 1717311767102
-- kind: conda
-  name: ca-certificates
-  version: 2024.6.2
-  build: hcefe29a_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.6.2-hcefe29a_0.conda
-  sha256: d27b90ff1e00c34123c37a4c5332bb75c3c5cc6775c57ecfa9f430b629ad3108
-  md5: 3ef6b1a30375f8a973a593698e317191
-  license: ISC
-  size: 156128
-  timestamp: 1717312862469
 - kind: conda
   name: ca-certificates
   version: 2024.6.2
@@ -1126,24 +954,6 @@ packages:
   license_family: MIT
   size: 294523
   timestamp: 1696001868949
-- kind: conda
-  name: cffi
-  version: 1.16.0
-  build: py312hf3c74c0_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-1.16.0-py312hf3c74c0_0.conda
-  sha256: 3b8e96c60a39c6d2180f5db4a7209b900c0a7dec218b9d15f42c0c99dd925792
-  md5: 2b087fcfbe35a1bb081e1723b8c6362a
-  depends:
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - pycparser
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  size: 310955
-  timestamp: 1696003981838
 - kind: conda
   name: cfgv
   version: 3.3.1
@@ -1460,21 +1270,6 @@ packages:
   size: 50277
   timestamp: 1719179035515
 - kind: conda
-  name: gcc
-  version: 12.3.0
-  build: hdb0cc85_13
-  build_number: 13
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-12.3.0-hdb0cc85_13.conda
-  sha256: 6a1e456f012a2c1f3cb8159223140cf0fad77a876390e2e8dfdffa1bc4433f19
-  md5: 7971f4057aa7946080d0a774f797e880
-  depends:
-  - gcc_impl_linux-aarch64 12.3.0.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 50174
-  timestamp: 1719179734501
-- kind: conda
   name: gcc_impl_linux-64
   version: 12.3.0
   build: h58ffeeb_13
@@ -1496,27 +1291,6 @@ packages:
   size: 60448133
   timestamp: 1719178921864
 - kind: conda
-  name: gcc_impl_linux-aarch64
-  version: 12.3.0
-  build: h3d98823_13
-  build_number: 13
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-12.3.0-h3d98823_13.conda
-  sha256: 1f3cdcdc65879c4d760fc01eb29af1cf6635dbd3898c6ac049e6b570bfae0085
-  md5: 795fdde6c0a6873489b60c202e80126c
-  depends:
-  - binutils_impl_linux-aarch64 >=2.40
-  - libgcc-devel_linux-aarch64 12.3.0 h6144e03_113
-  - libgcc-ng >=12.3.0
-  - libgomp >=12.3.0
-  - libsanitizer 12.3.0 h57e2e72_13
-  - libstdcxx-ng >=12.3.0
-  - sysroot_linux-aarch64
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 57846326
-  timestamp: 1719179577596
-- kind: conda
   name: gcc_linux-64
   version: 12.3.0
   build: h9528a6a_9
@@ -1533,23 +1307,6 @@ packages:
   license_family: BSD
   size: 31482
   timestamp: 1719005657097
-- kind: conda
-  name: gcc_linux-aarch64
-  version: 12.3.0
-  build: ha52a6ea_9
-  build_number: 9
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-12.3.0-ha52a6ea_9.conda
-  sha256: 86e799eff45c079530fd0c89bf66d7c4c77d1c6e77d3143c832dc0b4b1a33933
-  md5: 19df82a1e5e69e1b0e3b60c8af83a761
-  depends:
-  - binutils_linux-aarch64 2.40 h1f91aba_9
-  - gcc_impl_linux-aarch64 12.3.0.*
-  - sysroot_linux-aarch64
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 31591
-  timestamp: 1719005628456
 - kind: conda
   name: icu
   version: '73.2'
@@ -1608,24 +1365,6 @@ packages:
   license_family: GPL
   size: 1258066
   timestamp: 1711086600855
-- kind: conda
-  name: kernel-headers_linux-aarch64
-  version: 4.18.0
-  build: h5b4a56d_14
-  build_number: 14
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h5b4a56d_14.conda
-  sha256: c44b178b38de4126d50a71501ac9e1c49119bb7aba9d09ab861ba12bc8d4e21c
-  md5: 9b0446ad203105e5bbdda273a78d1d0f
-  depends:
-  - _sysroot_linux-aarch64_curr_repodata_hack 4.*
-  constrains:
-  - sysroot_linux-aarch64 ==2.17
-  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
-  license_family: GPL
-  size: 1114567
-  timestamp: 1708000894708
 - kind: conda
   name: ld64
   version: '711'
@@ -1722,21 +1461,6 @@ packages:
   size: 707602
   timestamp: 1718625640445
 - kind: conda
-  name: ld_impl_linux-aarch64
-  version: '2.40'
-  build: h9fc2d93_7
-  build_number: 7
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.40-h9fc2d93_7.conda
-  sha256: 4a6c0bd77e125da8472bd73bba7cd4169a3ce4699b00a3893026ae8664b2387d
-  md5: 1b0feef706f4d03eff0b76626ead64fc
-  constrains:
-  - binutils_impl_linux-aarch64 2.40
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 735885
-  timestamp: 1718625653417
-- kind: conda
   name: libclang-cpp16
   version: 16.0.6
   build: default_h4c8afb6_8
@@ -1798,22 +1522,6 @@ packages:
   license_family: Apache
   size: 1249309
   timestamp: 1715020018902
-- kind: conda
-  name: libexpat
-  version: 2.6.2
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.2-h2f0025b_0.conda
-  sha256: 07453df3232a649f39fb4d1e68cfe1c78c3457764f85225f6f3ccd1bdd9818a4
-  md5: 1b9f46b804a2c3c5d7fd6a80b77c35f9
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - expat 2.6.2.*
-  license: MIT
-  license_family: MIT
-  size: 72544
-  timestamp: 1710362309065
 - kind: conda
   name: libexpat
   version: 2.6.2
@@ -1901,21 +1609,6 @@ packages:
 - kind: conda
   name: libffi
   version: 3.4.2
-  build: h3557bc0_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2
-  sha256: 7e9258a102480757fe3faeb225a3ca04dffd10fecd2a958c65cdb4cdf75f2c3c
-  md5: dddd85f4d52121fab0a8b099c5e06501
-  depends:
-  - libgcc-ng >=9.4.0
-  license: MIT
-  license_family: MIT
-  size: 59450
-  timestamp: 1636488255090
-- kind: conda
-  name: libffi
-  version: 3.4.2
   build: h7f98852_5
   build_number: 5
   subdir: linux-64
@@ -1961,22 +1654,6 @@ packages:
   size: 2554344
   timestamp: 1719178746950
 - kind: conda
-  name: libgcc-devel_linux-aarch64
-  version: 12.3.0
-  build: h6144e03_113
-  build_number: 113
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-12.3.0-h6144e03_113.conda
-  sha256: 68734e1c2e1f9289c07e5dc1ee97855642e2a66a7e0ac841ca3dbd3ed13dde2f
-  md5: 742561068b48ab803c9524c0ebab6a70
-  depends:
-  - __unix
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 313403
-  timestamp: 1719179395710
-- kind: conda
   name: libgcc-ng
   version: 14.1.0
   build: h77fa898_0
@@ -1994,22 +1671,6 @@ packages:
   size: 842109
   timestamp: 1719538896937
 - kind: conda
-  name: libgcc-ng
-  version: 14.1.0
-  build: he277a41_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.1.0-he277a41_0.conda
-  sha256: b9ca03216bc089c0c46f008bc6f447bc0df8dc826d9801fb4283e49fa89c877e
-  md5: 47ecd1292a3fd78b616640b35dd9632c
-  depends:
-  - _openmp_mutex >=4.5
-  constrains:
-  - libgomp 14.1.0 he277a41_0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 532273
-  timestamp: 1719547536460
-- kind: conda
   name: libgomp
   version: 14.1.0
   build: h77fa898_0
@@ -2023,18 +1684,6 @@ packages:
   license_family: GPL
   size: 456925
   timestamp: 1719538796073
-- kind: conda
-  name: libgomp
-  version: 14.1.0
-  build: he277a41_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.1.0-he277a41_0.conda
-  sha256: 11f326e49e0fb92c2a52e870c029fc26b4b6d3eb9414fa4374cb8496b231a730
-  md5: 434ccc943b843117e4cebc97265f2504
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 459535
-  timestamp: 1719547432949
 - kind: conda
   name: libiconv
   version: '1.17'
@@ -2098,20 +1747,6 @@ packages:
 - kind: conda
   name: libnsl
   version: 2.0.1
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
-  sha256: fd18c2b75d7411096428d36a70b36b1a17e31f7b8956b6905d145792d49e97f8
-  md5: c14f32510f694e3185704d89967ec422
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-only
-  license_family: GPL
-  size: 34501
-  timestamp: 1697358973269
-- kind: conda
-  name: libnsl
-  version: 2.0.1
   build: hd590300_0
   subdir: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
@@ -2123,22 +1758,6 @@ packages:
   license_family: GPL
   size: 33408
   timestamp: 1697359010159
-- kind: conda
-  name: libsanitizer
-  version: 12.3.0
-  build: h57e2e72_13
-  build_number: 13
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-12.3.0-h57e2e72_13.conda
-  sha256: 3bb02de4d58dd6e7c0a96d8d955ee78e558eb6ffd4a9735f7108f9c31ab7511e
-  md5: f098b0e0cd029b5cfba5b8c93b8f6d67
-  depends:
-  - libgcc-ng >=12.3.0
-  - libstdcxx-ng >=12.3.0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 3958890
-  timestamp: 1719179525981
 - kind: conda
   name: libsanitizer
   version: 12.3.0
@@ -2201,20 +1820,6 @@ packages:
 - kind: conda
   name: libsqlite
   version: 3.46.0
-  build: hf51ef55_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.46.0-hf51ef55_0.conda
-  sha256: 7b48d006be6cd089105687fb524a2c93c4218bfc398d0611340cafec55249977
-  md5: a8ae63fd6fb7d007f74ef3df95e5edf3
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<2.0a0
-  license: Unlicense
-  size: 1043861
-  timestamp: 1718050586624
-- kind: conda
-  name: libsqlite
-  version: 3.46.0
   build: hfb93653_0
   subdir: osx-arm64
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.0-hfb93653_0.conda
@@ -2226,20 +1831,6 @@ packages:
   license: Unlicense
   size: 830198
   timestamp: 1718050644825
-- kind: conda
-  name: libstdcxx-ng
-  version: 14.1.0
-  build: h3f4de04_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.1.0-h3f4de04_0.conda
-  sha256: 4f2f35b78258d1a1e56b1b0e61091862c10ec76bf67ca1b0ff99dd5e07e76271
-  md5: 2f84852b723ac4389eb188db695526bb
-  depends:
-  - libgcc-ng 14.1.0 he277a41_0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 3805250
-  timestamp: 1719547563542
 - kind: conda
   name: libstdcxx-ng
   version: 14.1.0
@@ -2268,34 +1859,6 @@ packages:
   license_family: BSD
   size: 33601
   timestamp: 1680112270483
-- kind: conda
-  name: libuuid
-  version: 2.38.1
-  build: hb4cce97_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
-  sha256: 616277b0c5f7616c2cdf36f6c316ea3f9aa5bb35f2d4476a349ab58b9b91675f
-  md5: 000e30b09db0b7c775b21695dff30969
-  depends:
-  - libgcc-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 35720
-  timestamp: 1680113474501
-- kind: conda
-  name: libxcrypt
-  version: 4.4.36
-  build: h31becfc_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
-  sha256: 6b46c397644091b8a26a3048636d10b989b1bf266d4be5e9474bf763f828f41f
-  md5: b4df5d7d4b63579d081fd3a4cf99740e
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-or-later
-  size: 114269
-  timestamp: 1702724369203
 - kind: conda
   name: libxcrypt
   version: 4.4.36
@@ -2384,23 +1947,6 @@ packages:
   license_family: Other
   size: 61574
   timestamp: 1716874187109
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: h68df207_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h68df207_1.conda
-  sha256: 0d6dfd1e36e10c205ff1fdcf42d42289ff0f50be7a4eaa7b34f086a5e22a0734
-  md5: b13fb82f88902e34dd0638cd7d378c21
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - zlib 1.3.1 *_1
-  license: Zlib
-  license_family: Other
-  size: 67199
-  timestamp: 1716874136348
 - kind: conda
   name: libzlib
   version: 1.3.1
@@ -2604,19 +2150,6 @@ packages:
 - kind: conda
   name: ncurses
   version: '6.5'
-  build: h0425590_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-h0425590_0.conda
-  sha256: f8002feaa9e0eb929cd123f1275d8c0b3c6ffb7fd9269b192927009df19dc89e
-  md5: 38362af7bfac0efef69675acee564458
-  depends:
-  - libgcc-ng >=12
-  license: X11 AND BSD-3-Clause
-  size: 925099
-  timestamp: 1715194843316
-- kind: conda
-  name: ncurses
-  version: '6.5'
   build: h5846eda_0
   subdir: osx-64
   url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h5846eda_0.conda
@@ -2703,24 +2236,6 @@ packages:
   license_family: Apache
   size: 2896610
   timestamp: 1719363957188
-- kind: conda
-  name: openssl
-  version: 3.3.1
-  build: h68df207_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.1-h68df207_1.conda
-  sha256: 6923774922da4e974e561e1603e97d25ea2445b78db709493e72d140183abec2
-  md5: 8349df397000d7a7acb514d97879fe09
-  depends:
-  - ca-certificates
-  - libgcc-ng >=12
-  constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 3421944
-  timestamp: 1719364110495
 - kind: conda
   name: openssl
   version: 3.3.1
@@ -2893,36 +2408,6 @@ packages:
 - kind: conda
   name: python
   version: 3.12.4
-  build: h829453d_0_cpython
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.4-h829453d_0_cpython.conda
-  sha256: 21a308f92f6988e1a8169a8d46b43fbd1a6b638d0964d015a4444d7af05f00e1
-  md5: 48c28e5926b7c8ffe58f77991a43ca23
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-aarch64 >=2.36.1
-  - libexpat >=2.6.2,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.46.0,<4.0a0
-  - libuuid >=2.38.1,<3.0a0
-  - libxcrypt >=4.4.36
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.3.1,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  size: 12642375
-  timestamp: 1718618670784
-- kind: conda
-  name: python
-  version: 3.12.4
   build: h889d299_0_cpython
   subdir: win-64
   url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.4-h889d299_0_cpython.conda
@@ -2961,21 +2446,6 @@ packages:
   license_family: BSD
   size: 6385
   timestamp: 1695147396604
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 4_cp312
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.12-4_cp312.conda
-  sha256: 4f4c3389b722cac9bf39183221332ab69e468351030ec5359042b50c5d975a15
-  md5: 6c09f8e580146d88f649780cebed01de
-  constrains:
-  - python 3.12.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6417
-  timestamp: 1695147418374
 - kind: conda
   name: python_abi
   version: '3.12'
@@ -3077,25 +2547,6 @@ packages:
 - kind: conda
   name: pyyaml
   version: 6.0.1
-  build: py312hdd3e373_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.1-py312hdd3e373_1.conda
-  sha256: fa340199dd5e6f9a27af535066caa9a95ee66f3f75d8f3a8966e2541d48f052a
-  md5: 6955fe2d94dfdeda4690876d01437af1
-  depends:
-  - libgcc-ng >=12
-  - python >=3.12.0rc3,<3.13.0a0
-  - python >=3.12.0rc3,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 186843
-  timestamp: 1695373817252
-- kind: conda
-  name: pyyaml
-  version: 6.0.1
   build: py312he70551f_1
   build_number: 1
   subdir: win-64
@@ -3129,22 +2580,6 @@ packages:
   license_family: GPL
   size: 281456
   timestamp: 1679532220005
-- kind: conda
-  name: readline
-  version: '8.2'
-  build: h8fc344f_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8fc344f_1.conda
-  sha256: 4c99f7417419734e3797d45bc355e61c26520e111893b0d7087a01a7fbfbe3dd
-  md5: 105eb1e16bf83bfb2eb380a48032b655
-  depends:
-  - libgcc-ng >=12
-  - ncurses >=6.3,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 294092
-  timestamp: 1679532238805
 - kind: conda
   name: readline
   version: '8.2'
@@ -3194,24 +2629,6 @@ packages:
   license_family: MIT
   size: 195701375
   timestamp: 1718633036741
-- kind: conda
-  name: rust
-  version: 1.79.0
-  build: h3393a65_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/rust-1.79.0-h3393a65_0.conda
-  sha256: 3965fda1754fda9b9ad1c7be52459319a1c599021cf51d326fada2d39e3d9f34
-  md5: 2b0d80018e381412006dce52628fa36a
-  depends:
-  - gcc_impl_linux-aarch64
-  - libgcc-ng >=12
-  - libzlib >=1.3.1,<2.0a0
-  - rust-std-aarch64-unknown-linux-gnu 1.79.0 hbe8e118_0
-  - sysroot_linux-aarch64 >=2.17
-  license: MIT
-  license_family: MIT
-  size: 288583849
-  timestamp: 1718635713535
 - kind: conda
   name: rust
   version: 1.79.0
@@ -3305,23 +2722,6 @@ packages:
   license_family: MIT
   size: 30724150
   timestamp: 1718632528157
-- kind: conda
-  name: rust-std-aarch64-unknown-linux-gnu
-  version: 1.79.0
-  build: hbe8e118_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-unknown-linux-gnu-1.79.0-hbe8e118_0.conda
-  sha256: 2224c5ffbfc848cfa4fecc96aa263be96f582b4d58337fba592eecb2e295cf90
-  md5: 18c3ad86c103ffe98d19db3312bfc2ad
-  depends:
-  - __unix
-  constrains:
-  - rust >=1.79.0,<1.79.1.0a0
-  license: MIT
-  license_family: MIT
-  size: 46617327
-  timestamp: 1718633732148
 - kind: conda
   name: rust-std-wasm32-unknown-unknown
   version: 1.79.0
@@ -3470,23 +2870,6 @@ packages:
   size: 26421592
   timestamp: 1711086612058
 - kind: conda
-  name: sysroot_linux-aarch64
-  version: '2.17'
-  build: h5b4a56d_14
-  build_number: 14
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_14.conda
-  sha256: d239232cff55b45a1fbdea9fc660492afca16ba950785d9da3504f16de8fe765
-  md5: ba47875acf57f2717bcd55b26f4c3e00
-  depends:
-  - _sysroot_linux-aarch64_curr_repodata_hack 4.*
-  - kernel-headers_linux-aarch64 4.18.0 h5b4a56d_14
-  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
-  license_family: GPL
-  size: 16253097
-  timestamp: 1708000911838
-- kind: conda
   name: tapi
   version: 1100.0.11
   build: h9ce4665_0
@@ -3514,21 +2897,6 @@ packages:
   license_family: MIT
   size: 191416
   timestamp: 1602687595316
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: h194ca79_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
-  sha256: 7fa27cc512d3a783f38bd16bbbffc008807372499d5b65d089a8e43bde9db267
-  md5: f75105e0585851f818e0009dd1dde4dc
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3351802
-  timestamp: 1695506242997
 - kind: conda
   name: tk
   version: 8.6.13
@@ -3592,20 +2960,6 @@ packages:
   license_family: BSD
   size: 3318875
   timestamp: 1699202167581
-- kind: conda
-  name: typos
-  version: 1.22.7
-  build: h09b8157_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/typos-1.22.7-h09b8157_0.conda
-  sha256: df203105c159003d990fdf4814639dfa51a8ff725af59f065d7288a1e8e3cd6b
-  md5: a0e23be4b3d12fb7637e7f2a33a3a945
-  depends:
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 3575256
-  timestamp: 1718216174241
 - kind: conda
   name: typos
   version: 1.22.7
@@ -3673,21 +3027,6 @@ packages:
 - kind: conda
   name: typst
   version: 0.11.1
-  build: h00d8b65_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/typst-0.11.1-h00d8b65_0.conda
-  sha256: 5b612e595a5fa502774afb5f64ab92bc7b78d12c9ec09e454c06652a1af3b8e0
-  md5: cd988af0ddd31ad1ed9eeef248aa1a4f
-  depends:
-  - libgcc-ng >=12
-  - openssl >=3.3.0,<4.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 11328201
-  timestamp: 1716008155159
-- kind: conda
-  name: typst
-  version: 0.11.1
   build: h3c1dd8f_0
   subdir: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/typst-0.11.1-h3c1dd8f_0.conda
@@ -3748,22 +3087,6 @@ packages:
   license_family: Apache
   size: 11459647
   timestamp: 1716008214730
-- kind: conda
-  name: typst-test
-  version: 0.0.0.post104.7babfc0
-  build: h09b8157_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/typst-test-0.0.0.post104.7babfc0-h09b8157_0.conda
-  sha256: 6dea24ce23e2cd287b1093908ec6a7668bcb4e2ab031074d91d8b46ce1fc0063
-  md5: ede20c9f2f4666c78d7a724a79c1efbe
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - __glibc >=2.17
-  license: MIT
-  license_family: MIT
-  size: 1022525
-  timestamp: 1719429628505
 - kind: conda
   name: typst-test
   version: 0.0.0.post104.7babfc0
@@ -3929,26 +3252,6 @@ packages:
   size: 14050
   timestamp: 1695549556745
 - kind: conda
-  name: ukkonen
-  version: 1.0.1
-  build: py312h8f0b210_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ukkonen-1.0.1-py312h8f0b210_4.conda
-  sha256: 1660c56757ef39b3b467f1e2d6d51d236d36d426afa701dcbf71887e93c9f095
-  md5: 6761f5b303f3fcb695ae5f297cde7bde
-  depends:
-  - cffi
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - python >=3.12.0rc3,<3.13.0a0
-  - python >=3.12.0rc3,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  size: 14812
-  timestamp: 1695549601083
-- kind: conda
   name: vc
   version: '14.3'
   build: h8a93ad2_20
@@ -4096,19 +3399,6 @@ packages:
   size: 217804
   timestamp: 1660346976440
 - kind: conda
-  name: xz
-  version: 5.2.6
-  build: h9cdd2b7_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
-  sha256: 93f58a7b393adf41fa007ac8c55978765e957e90cd31877ece1e5a343cb98220
-  md5: 83baad393a31d59c20b63ba4da6592df
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1 and GPL-2.0
-  size: 440555
-  timestamp: 1660348056328
-- kind: conda
   name: yaml
   version: 0.2.5
   build: h0d85af4_2
@@ -4165,21 +3455,6 @@ packages:
   license_family: MIT
   size: 63274
   timestamp: 1641347623319
-- kind: conda
-  name: yaml
-  version: 0.2.5
-  build: hf897c2e_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-hf897c2e_2.tar.bz2
-  sha256: 8bc601d6dbe249eba44b3c456765265cd8f42ef1e778f8df9b0c9c88b8558d7e
-  md5: b853307650cb226731f653aa623936a4
-  depends:
-  - libgcc-ng >=9.4.0
-  license: MIT
-  license_family: MIT
-  size: 92927
-  timestamp: 1641347626613
 - kind: conda
   name: zstd
   version: 1.5.6

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 description = "Add a short description here"
 authors = ["Adrian Freund <adrian@freund.io>"]
 channels = ["conda-forge"]
-platforms = ["linux-64", "linux-aarch64", "win-64", "osx-64", "osx-arm64"]
+platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
+
+[system-requirements]
+macos = "11.0"
 
 [dependencies]
 
@@ -33,6 +36,7 @@ test-clean = "typst-test clean"
 
 [feature.lint.dependencies]
 typos = ">=1.22.7,<1.23"
+actionlint = ">=1.7.1,<1.8"
 
 [feature.pre-commit.dependencies]
 pre-commit = ">=3.1.1,<3.2"


### PR DESCRIPTION
linux-aarch64 support had to be removed for now, because actionlint isn't packaged for it yet. See https://github.com/conda-forge/actionlint-feedstock/pull/2